### PR TITLE
Automate Heimdall flashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+PyQt6


### PR DESCRIPTION
## Summary
- add constants and instructions for TWRP auto flashing
- implement `check_heimdall`, `detect_device`, `download_twrp`, and improved `flash_recovery`
- add `auto_flash_j3` and helper to run it from the GUI
- introduce `start_auto_flash` and button in `MainWindow`

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile flash.py`
- `python flash.py` *(fails: Could not load the Qt platform plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687918cd97fc8322922ba0a14de81178