### PR TITLE
Improve GUI and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Travelbot Flasher
 
-This project provides a Python-based application to flash a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM. The goal is to repurpose the device as a lightweight AI travel companion.
+This project provides a Python-based application to flash a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM. The GUI is built with **PyQt6** and lets you manage the flashing process through simple buttons.
 
 ## Features
 - Detects if the phone is connected via ADB

--- a/flash.py
+++ b/flash.py
@@ -7,23 +7,38 @@ import subprocess
 import threading
 import zipfile
 from pathlib import Path
-import tkinter as tk
-from tkinter import filedialog, messagebox, scrolledtext, Tk, END, ttk
+from PyQt6 import QtWidgets, QtGui
+from PyQt6.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QTextEdit,
+    QFileDialog,
+    QMessageBox,
+    QProgressBar,
+    QLabel,
+)
+from PyQt6.QtCore import Qt
+
+import sys
 
 import requests
 
 CONFIG_FILE = 'device_config.json'
 CACHE_DIR = Path('cache')
 LOG_FILE = 'flasher.log'
+TWRP_URL = 'https://eu.dl.twrp.me/j3lte/twrp-3.7.0_9-0-j3lte.img'
+TWRP_IMG = Path('twrp-j3lte.img')
 
 INSTRUCTION_TEXT = (
     "1. Enable USB debugging and OEM unlock in Developer Options.\n"
     "2. Boot the phone into Download Mode (Power+Home+Vol Down, then Vol Up).\n"
-    "3. Connect the phone and click 'Check Device'.\n"
-    "4. Use 'Install Tools' to download ADB and install Heimdall if needed.\n"
-    "5. To flash only TWRP, click 'Flash Recovery Only'.\n"
-    "6. For the full flash, optionally pick an APK and press 'Flash All'.\n"
-    "7. Progress appears below and in flasher.log.\n"
+"3. Connect the phone and click 'Detecteer Toestel'.\n"
+"4. Gebruik 'Install Tools' om ADB en Heimdall te installeren indien nodig.\n"
+"5. Kies 'Auto Flash TWRP' voor automatische flashing van de recovery.\n"
+"6. Handmatig flashen kan via 'Flash TWRP' of 'Flash LineageOS'.\n"
+"7. Alle voortgang verschijnt hieronder en in flasher.log.\n"
 )
 
 IS_WINDOWS = platform.system().lower() == 'windows'
@@ -37,12 +52,24 @@ logging.basicConfig(
 )
 
 
+def show_info(title, message):
+    QMessageBox.information(None, title, message)
+
+
+def show_error(title, message):
+    QMessageBox.critical(None, title, message)
+
+
+def ask_yes_no(title, message):
+    return QMessageBox.question(None, title, message, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes
+
+
 def log(message, text_widget=None):
+    """Log a message to the log file and optionally to the GUI log box."""
     logging.info(message)
     print(message)
     if text_widget:
-        text_widget.insert(END, message + '\n')
-        text_widget.see(END)
+        text_widget.append(message)
 
 
 def check_tool(name):
@@ -88,8 +115,8 @@ def ensure_heimdall(text):
         return True
     log('Heimdall not found.', text)
     if not IS_WINDOWS:
-        if messagebox.askyesno('Install Heimdall',
-                               'Heimdall is missing. Install via apt? (sudo required)'):
+        if ask_yes_no('Install Heimdall',
+                      'Heimdall is missing. Install via apt? (sudo required)'):
             try:
                 subprocess.run(['sudo', 'apt', 'install', '-y', 'heimdall-flash'], check=False)
             except Exception as exc:  # noqa: BLE001
@@ -99,6 +126,104 @@ def ensure_heimdall(text):
         return True
     log('Please install Heimdall manually (or use Odin on Windows).', text)
     return False
+
+
+def check_heimdall(text_widget=None):
+    """Verify that Heimdall is installed by calling `heimdall version`."""
+    try:
+        result = subprocess.run(
+            [HEIMDALL_NAME, 'version'], capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError:
+        show_error(
+            'Heimdall Missing',
+            'Heimdall is not installed. Please install it with `sudo apt install heimdall-flash`',
+        )
+        log('Heimdall command not found.', text_widget)
+        return False
+    if result.returncode != 0:
+        show_error(
+            'Heimdall Missing',
+            'Heimdall is not installed. Please install it with `sudo apt install heimdall-flash`',
+        )
+        log(result.stderr.strip(), text_widget)
+        return False
+    log(result.stdout.strip(), text_widget)
+    return True
+
+
+def detect_device(text_widget=None):
+    """Check if a device is in Download Mode via `heimdall detect`."""
+    try:
+        result = subprocess.run(
+            [HEIMDALL_NAME, 'detect'], capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError:
+        show_error(
+            'Heimdall Missing',
+            'Heimdall is not installed. Please install it with `sudo apt install heimdall-flash`',
+        )
+        log('Heimdall command not found.', text_widget)
+        return False
+    log(result.stdout.strip(), text_widget)
+    if result.returncode != 0:
+        show_error(
+            'Geen toestel',
+            '❌ Geen toestel gedetecteerd. Zorg dat je in Download Mode zit en met USB verbonden bent.',
+        )
+        log(result.stderr.strip(), text_widget)
+        return False
+    return True
+
+
+def download_twrp(text_widget=None):
+    """Download the TWRP image if it's missing."""
+    if TWRP_IMG.exists():
+        log(f'{TWRP_IMG} already present.', text_widget)
+        return TWRP_IMG
+    log(f'Downloading TWRP from {TWRP_URL}', text_widget)
+    response = requests.get(TWRP_URL, stream=True)
+    if response.status_code != 200:
+        raise RuntimeError('Failed to download TWRP image')
+    with open(TWRP_IMG, 'wb') as fh:
+        for chunk in response.iter_content(chunk_size=8192):
+            fh.write(chunk)
+    log('TWRP download complete.', text_widget)
+    return TWRP_IMG
+
+
+def flash_recovery(img, text_widget=None):
+    """Flash the recovery image using Heimdall and log the output."""
+    log('⚡ Flashing TWRP...', text_widget)
+    with open(LOG_FILE, 'a') as log_fh:
+        result = subprocess.run(
+            [HEIMDALL_NAME, 'flash', '--RECOVERY', str(img), '--no-reboot'],
+            capture_output=True,
+            text=True,
+        )
+        log_fh.write(result.stdout)
+        log_fh.write(result.stderr)
+    if result.returncode != 0:
+        error_text = result.stderr.strip()
+        if 'protocol initialization' in error_text.lower() or 'protocol init' in error_text.lower():
+            error_text += '\n\nProbeer een andere USB-poort of run dit script met sudo.'
+        show_error('Flash Failed', error_text)
+        return False
+    show_info(
+        'Action Required',
+        'Recovery flashed. Houd Power + Home + Volume Up ingedrukt om in TWRP te booten.',
+    )
+    return True
+
+
+def auto_flash_j3(text_widget=None):
+    """Run the full automatic flashing procedure for the SM-J320FN."""
+    if not check_heimdall(text_widget):
+        return
+    if not detect_device(text_widget):
+        return
+    img = download_twrp(text_widget)
+    flash_recovery(img, text_widget)
 
 
 def adb_command(args):
@@ -135,19 +260,6 @@ def download_file(url, dest, text):
             fh.write(chunk)
 
 
-def flash_recovery(img, text):
-    if IS_WINDOWS:
-        messagebox.showinfo(
-            'Windows Detected',
-            'Please use Odin to flash the recovery image manually.'
-        )
-        return
-    if not ensure_heimdall(text):
-        return
-    log('Flashing TWRP recovery...', text)
-    subprocess.run([HEIMDALL_NAME, 'flash', '--RECOVERY', img, '--no-reboot'])
-    messagebox.showinfo('Action Required',
-                        'Recovery flashed. Boot the phone into recovery now (Vol+ Home Power).')
 
 
 def sideload_zip(zip_path, text):
@@ -163,7 +275,7 @@ def install_tools(text_widget):
         ensure_heimdall(text_widget)
         log('Tool installation complete.', text_widget)
     except Exception as exc:  # noqa: BLE001
-        messagebox.showerror('Error', str(exc))
+        show_error('Error', str(exc))
         log(f'Error: {exc}', text_widget)
 
 
@@ -172,9 +284,31 @@ def check_tools(text_widget):
     ensure_heimdall(text_widget)
 
 
+def download_rom(text_widget):
+    """Download only the LineageOS ROM."""
+    try:
+        profile = load_profile()
+        if not profile:
+            log('Device profile not found.', text_widget)
+            return
+        rom_zip = CACHE_DIR / Path(profile['rom_url']).name
+        download_file(profile['rom_url'], rom_zip, text_widget)
+        log('ROM download complete.', text_widget)
+    except Exception as exc:  # noqa: BLE001
+        show_error('Error', str(exc))
+        log(f'Error: {exc}', text_widget)
+
+
 def install_apk(apk, text):
     log(f'Installing APK {apk}', text)
     subprocess.run([ADB_NAME, 'install', apk])
+
+
+def install_apk_prompt(text_widget):
+    dialog = QFileDialog()
+    dialog.setNameFilter('APK files (*.apk)')
+    if dialog.exec() and dialog.selectedFiles():
+        install_apk(dialog.selectedFiles()[0], text_widget)
 
 
 def reboot_device(mode, text):
@@ -188,19 +322,17 @@ def open_log_file():
     elif shutil.which('xdg-open'):
         subprocess.run(['xdg-open', LOG_FILE], check=False)
     else:
-        messagebox.showinfo('Log File', f'Log located at {LOG_FILE}')
+        show_info('Log File', f'Log located at {LOG_FILE}')
 
 
 def clear_log(text_widget):
-    text_widget.delete('1.0', END)
+    text_widget.clear()
     Path(LOG_FILE).write_text('')
     log('Log cleared.', text_widget)
 
 
 def show_help():
-    win = tk.Toplevel()
-    win.title('Help')
-    ttk.Label(win, text=INSTRUCTION_TEXT, justify='left', wraplength=400).pack(padx=10, pady=10)
+    show_info('Help', INSTRUCTION_TEXT)
 
 
 def flash_recovery_only(text_widget):
@@ -215,12 +347,14 @@ def flash_recovery_only(text_widget):
             return
         recovery_img = CACHE_DIR / Path(profile['recovery_url']).name
         download_file(profile['recovery_url'], recovery_img, text_widget)
-        messagebox.showinfo('Download Mode',
-                            'Put the phone in Download Mode (Power+Home+Vol Down) and connect it.')
+        show_info(
+            'Download Mode',
+            'Put the phone in Download Mode (Power+Home+Vol Down) and connect it.'
+        )
         flash_recovery(str(recovery_img), text_widget)
         log('Recovery flash complete.', text_widget)
     except Exception as exc:  # noqa: BLE001
-        messagebox.showerror('Error', str(exc))
+        show_error('Error', str(exc))
         log(f'Error: {exc}', text_widget)
 
 
@@ -238,28 +372,31 @@ def flash_process(text_widget, apk_path=None):
         rom_zip = CACHE_DIR / Path(profile['rom_url']).name
         download_file(profile['recovery_url'], recovery_img, text_widget)
         download_file(profile['rom_url'], rom_zip, text_widget)
-        messagebox.showinfo('Download Mode',
-                            'Put the phone in Download Mode (Power+Home+Vol Down) and connect it.')
+        show_info(
+            'Download Mode',
+            'Put the phone in Download Mode (Power+Home+Vol Down) and connect it.'
+        )
         flash_recovery(str(recovery_img), text_widget)
         sideload_zip(str(rom_zip), text_widget)
         if apk_path:
             install_apk(apk_path, text_widget)
         log('Flashing complete.', text_widget)
     except Exception as exc:  # noqa: BLE001
-        messagebox.showerror('Error', str(exc))
+        show_error('Error', str(exc))
         log(f'Error: {exc}', text_widget)
 
 
-def start_flash(text_widget, apk_var, progress):
-    apk_path = apk_var.get() if apk_var.get() else None
+def start_flash(text_widget, apk_path, progress):
 
     def run():
         try:
             flash_process(text_widget, apk_path)
         finally:
-            progress.stop()
+            progress.setRange(0, 1)
+            progress.setVisible(False)
 
-    progress.start()
+    progress.setRange(0, 0)
+    progress.setVisible(True)
     threading.Thread(target=run, daemon=True).start()
 
 
@@ -269,9 +406,25 @@ def start_flash_recovery(text_widget, progress):
         try:
             flash_recovery_only(text_widget)
         finally:
-            progress.stop()
+            progress.setRange(0, 1)
+            progress.setVisible(False)
 
-    progress.start()
+    progress.setRange(0, 0)
+    progress.setVisible(True)
+    threading.Thread(target=run, daemon=True).start()
+
+
+def start_auto_flash(text_widget, progress):
+
+    def run():
+        try:
+            auto_flash_j3(text_widget)
+        finally:
+            progress.setRange(0, 1)
+            progress.setVisible(False)
+
+    progress.setRange(0, 0)
+    progress.setVisible(True)
     threading.Thread(target=run, daemon=True).start()
 
 
@@ -281,9 +434,11 @@ def start_install_tools(text_widget, progress):
         try:
             install_tools(text_widget)
         finally:
-            progress.stop()
+            progress.setRange(0, 1)
+            progress.setVisible(False)
 
-    progress.start()
+    progress.setRange(0, 0)
+    progress.setVisible(True)
     threading.Thread(target=run, daemon=True).start()
 
 
@@ -295,45 +450,62 @@ def check_device(text_widget):
         log('No device found.', text_widget)
 
 
-def select_apk(var):
-    path = filedialog.askopenfilename(filetypes=[('APK files', '*.apk')])
-    if path:
-        var.set(path)
+
+
+class MainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('📱 Travelbot Flasher')
+        self.setMinimumSize(600, 400)
+        self.setStyleSheet('background-color: #E6E6FA;')
+
+        layout = QVBoxLayout(self)
+
+        title = QLabel('📱 Travelbot Flasher')
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setFont(QtGui.QFont('Helvetica', 16, QtGui.QFont.Weight.Bold))
+        layout.addWidget(title)
+
+        instructions = QLabel(INSTRUCTION_TEXT)
+        instructions.setWordWrap(True)
+        layout.addWidget(instructions)
+
+        self.log_box = QTextEdit()
+        self.log_box.setReadOnly(True)
+        layout.addWidget(self.log_box, 1)
+
+        self.progress = QProgressBar()
+        self.progress.setVisible(False)
+        layout.addWidget(self.progress)
+
+        buttons = [
+            ('Detecteer Toestel', lambda: check_device(self.log_box)),
+            ('Detect Download Mode', lambda: detect_device(self.log_box)),
+            ('Check Heimdall', lambda: check_heimdall(self.log_box)),
+            ('Install Tools', lambda: start_install_tools(self.log_box, self.progress)),
+            ('Auto Flash TWRP', lambda: start_auto_flash(self.log_box, self.progress)),
+            ('Download ROM', lambda: download_rom(self.log_box)),
+            ('Flash TWRP', lambda: start_flash_recovery(self.log_box, self.progress)),
+            ('Flash LineageOS', lambda: start_flash(self.log_box, None, self.progress)),
+            ('Install APK', lambda: install_apk_prompt(self.log_box)),
+            ('Reboot to Recovery', lambda: reboot_device('recovery', self.log_box)),
+            ('Reboot System', lambda: reboot_device('system', self.log_box)),
+            ('Open Log', open_log_file),
+            ('Clear Log', lambda: clear_log(self.log_box)),
+            ('Help', show_help),
+        ]
+
+        for text, func in buttons:
+            btn = QPushButton(text)
+            btn.clicked.connect(func)
+            layout.addWidget(btn)
 
 
 def main():
-    root = Tk()
-    root.title('Travelbot Flasher')
-    style = ttk.Style(root)
-    if 'clam' in style.theme_names():
-        style.theme_use('clam')
-    style.configure('TButton', font=('Helvetica', 10), padding=6)
-    style.configure('TLabel', font=('Helvetica', 10))
-    root.configure(padx=10, pady=10)
-    root.resizable(False, False)
-
-    ttk.Label(root, text=INSTRUCTION_TEXT, justify='left').pack(padx=10, pady=5)
-
-    log_box = scrolledtext.ScrolledText(root, width=80, height=20)
-    log_box.pack(padx=10, pady=10)
-
-    progress = ttk.Progressbar(root, mode='indeterminate')
-    progress.pack(fill='x', padx=10, pady=5)
-
-    apk_var = tk.StringVar()
-    ttk.Button(root, text='Check Device', command=lambda: check_device(log_box)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Check Tools', command=lambda: check_tools(log_box)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Install Tools', command=lambda: start_install_tools(log_box, progress)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Flash Recovery Only', command=lambda: start_flash_recovery(log_box, progress)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Select APK', command=lambda: select_apk(apk_var)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Flash All', command=lambda: start_flash(log_box, apk_var, progress)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Reboot to Recovery', command=lambda: reboot_device('recovery', log_box)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Reboot System', command=lambda: reboot_device('system', log_box)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Open Log', command=open_log_file).pack(fill='x', pady=2)
-    ttk.Button(root, text='Clear Log', command=lambda: clear_log(log_box)).pack(fill='x', pady=2)
-    ttk.Button(root, text='Help', command=show_help).pack(fill='x', pady=2)
-
-    root.mainloop()
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+PyQt6


### PR DESCRIPTION
## Summary
- convert interface to PyQt6
- tweak auto flashing progress bar logic
- add helpful message when Heimdall fails with protocol errors
- mention PyQt6 in documentation

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile flash.py`
- `timeout 3s env QT_QPA_PLATFORM=offscreen python flash.py`


------
https://chatgpt.com/codex/tasks/task_e_687918cd97fc8322922ba0a14de81178