### PR TITLE
Add docs landing page with navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Travelbot Flasher Docs
+
+These HTML pages can be viewed locally or published with GitHub Pages. Enable Pages for the `docs/` folder in your repository settings to host them.
+
+- `index.html` – short introduction and navigation
+- `frequent-issues.html` – instructions for solving Factory Reset Protection (FRP) lock and other common problems
+
+The styling and behaviour are implemented in `style.css` and `script.js`.

--- a/docs/frequent-issues.html
+++ b/docs/frequent-issues.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <title>Frequent issues - FRP Lock oplossen</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="frequent-issues.html" class="active">Frequent issues</a>
+  </nav>
+  <div class="container">
+    <h1>🔓 FRP Lock oplossen (Samsung Galaxy J3 - SM-J320FN)</h1>
+    <p>Als je bij het flashen van TWRP deze foutmelding ziet:</p>
+    <blockquote>❌ "Custom Binary blocked by FRP Lock"</blockquote>
+    <p>Dan blokkeert Samsung de installatie van aangepaste software. Dit komt door <strong>Factory Reset Protection (FRP)</strong>. Hieronder lees je hoe je dit oplost.</p>
+    <h2>✅ Stap-voor-stap: FRP Lock uitschakelen</h2>
+
+    <div class="step">
+      <h3 class="toggle">1. Zet <strong>OEM Unlock</strong> aan</h3>
+      <ol>
+        <li>Ga op je huidige Android-installatie naar:<br>Instellingen → Over de telefoon → Software-informatie</li>
+        <li>Tik 7x op <strong>Buildnummer</strong> om ontwikkelaarsopties te activeren</li>
+        <li>Ga terug naar:<br>Instellingen → Ontwikkelaarsopties</li>
+        <li>Zet <strong>OEM-ontgrendeling</strong> aan</li>
+      </ol>
+      <p class="note">ℹ️ Zie je deze optie niet? Zorg dat het toestel verbonden is met WiFi en wacht eventueel enkele dagen (soms 7 dagen na reset vereist).</p>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">2. Verwijder je <strong>Google-account</strong></h3>
+      <ul>
+        <li>Ga naar:<br><code>Instellingen → Accounts → Google → Verwijderen</code></li>
+        <li>Zet ook je schermvergrendeling uit bij<br><code>Instellingen → Beveiliging → Schermvergrendeling</code></li>
+      </ul>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">3. Zet toestel opnieuw in Download Mode</h3>
+      <ul>
+        <li>Zet je toestel uit</li>
+        <li>Houd <strong>Volume omlaag + Home + Power</strong> ingedrukt</li>
+        <li>Druk daarna op <strong>Volume omhoog</strong> om verder te gaan</li>
+      </ul>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">4. Flash TWRP opnieuw</h3>
+      <p>Gebruik je flashtool of het volgende commando:</p>
+      <pre><code>heimdall flash --RECOVERY twrp-j3lte.img --no-reboot</code></pre>
+    </div>
+
+    <div class="info">
+      <p><strong>ℹ️ Wat is FRP?</strong></p>
+      <p>FRP (Factory Reset Protection) voorkomt dat een toestel opnieuw gebruikt wordt zonder toestemming van de vorige eigenaar. Het is bedoeld als antidiefstalbeveiliging, maar zit ook gewone gebruikers in de weg bij het flashen.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Travelbot Flasher Docs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html" class="active">Home</a>
+    <a href="frequent-issues.html">Frequent issues</a>
+  </nav>
+  <div class="container">
+    <h1>Travelbot Flasher</h1>
+    <p>This site hosts documentation for the Travelbot flasher tool.</p>
+    <p>The application flashes a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM and provides a GUI built with PyQt6.</p>
+    <p>Browse the <strong>Frequent issues</strong> tab for help with common problems such as FRP lock.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.step').forEach(step => {
+    const header = step.querySelector('.toggle');
+    header.addEventListener('click', () => {
+      step.classList.toggle('collapsed');
+    });
+  });
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,78 @@
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  background-color: #f9f9f9;
+  color: #333;
+}
+
+nav {
+  background: #333;
+  padding: 10px;
+  text-align: center;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 10px;
+  text-decoration: none;
+}
+
+nav a.active {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+h1 {
+  text-align: center;
+}
+
+blockquote {
+  background: #ffe4e4;
+  padding: 10px;
+  border-left: 4px solid #ff0000;
+}
+
+.step {
+  margin-top: 20px;
+}
+
+.step h3 {
+  cursor: pointer;
+  background: #e0e0e0;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.step ul,
+.step ol,
+.step pre,
+.step p:not(.toggle) {
+  margin-left: 20px;
+}
+
+.step.collapsed ul,
+.step.collapsed ol,
+.step.collapsed pre,
+.step.collapsed p:not(.toggle) {
+  display: none;
+}
+
+.note {
+  font-style: italic;
+  color: #555;
+}
+
+.info {
+  margin-top: 30px;
+  background: #e8f5e9;
+  padding: 10px;
+  border-left: 4px solid #4caf50;
+}


### PR DESCRIPTION
## Summary
- move FRP guide into `frequent-issues.html`
- add a docs landing page and navigation bar
- style navigation and create README for hosting the docs

## Testing
- `python -m py_compile flash.py`


------
https://chatgpt.com/codex/tasks/task_e_687932502a748322b224a1bd71936299