### PR TITLE
Add root access tab and Magisk automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ The interface includes buttons to check devices and tools, flash only the recove
 2. Power off the phone, then hold **Power + Home + Volume Down** to enter **Download Mode**. Press **Volume Up** to continue.
 3. Connect the device via USB before starting the flash process.
 
+## Rooting with Magisk
+
+To obtain root access on the Galaxy J3 (SM-J320FN) you need TWRP installed first.
+From the flasher tool open the **🔓 Geef Root-toegang** tab and use the
+**Download Magisk.zip** button to fetch `Magisk-v23.0.zip` if you don't already
+have it. Push the zip to the phone with **Flash Magisk via TWRP** and then boot
+to TWRP manually. In TWRP choose <code>Install → Magisk-v23.0.zip</code> and
+flash the file. Reboot Android and verify the root status using the
+"Controleer Rootstatus" button or by running `adb shell su -v`.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ These HTML pages can be viewed locally or published with GitHub Pages. Enable Pa
 
 - `index.html` – short introduction and navigation
 - `frequent-issues.html` – instructions for solving Factory Reset Protection (FRP) lock and other common problems
+- `rooting-j3.html` – step-by-step guide for rooting the Samsung Galaxy J3
 
 The styling and behaviour are implemented in `style.css` and `script.js`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,12 +9,13 @@
   <nav>
     <a href="index.html" class="active">Home</a>
     <a href="frequent-issues.html">Frequent issues</a>
+    <a href="rooting-j3.html">Rooting</a>
   </nav>
   <div class="container">
     <h1>Travelbot Flasher</h1>
     <p>This site hosts documentation for the Travelbot flasher tool.</p>
     <p>The application flashes a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM and provides a GUI built with PyQt6.</p>
-    <p>Browse the <strong>Frequent issues</strong> tab for help with common problems such as FRP lock.</p>
+    <p>Browse the <strong>Frequent issues</strong> tab for help with common problems such as FRP lock. For rooting instructions see the <strong>Rooting</strong> page.</p>
   </div>
   <script src="script.js"></script>
 </body>

--- a/docs/rooting-j3.html
+++ b/docs/rooting-j3.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <title>Rooting Samsung Galaxy J3</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="frequent-issues.html">Frequent issues</a>
+    <a href="rooting-j3.html" class="active">Rooting</a>
+  </nav>
+  <div class="container">
+    <h1>🔓 Samsung Galaxy J3 Rooten</h1>
+    <p>Root-toegang is optioneel maar vereist voor diepere systeemtoegang. Gebruik Magisk v23.0 dat geen boot.img patching nodig heeft.</p>
+    <div class="step">
+      <h3 class="toggle">1. Installeer TWRP</h3>
+      <p>Flash TWRP via de flasher of met Heimdall:</p>
+      <pre><code>heimdall flash --RECOVERY twrp-j3lte.img --no-reboot</code></pre>
+    </div>
+    <div class="step">
+      <h3 class="toggle">2. Download Magisk</h3>
+      <p>Gebruik de knop <em>Download Magisk.zip</em> in de tool of download handmatig: <code>Magisk-v23.0.zip</code>.</p>
+    </div>
+    <div class="step">
+      <h3 class="toggle">3. Flash Magisk</h3>
+      <ol>
+        <li>Kopieer het zip-bestand naar <code>/sdcard/</code> (knop "Flash Magisk via TWRP" doet dit automatisch).</li>
+        <li>Boot naar TWRP.</li>
+        <li>Kies <strong>Install</strong> → <code>Magisk-v23.0.zip</code>.</li>
+        <li>Swipe om te flashen en reboot daarna het systeem.</li>
+      </ol>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split main window into two tabs
- implement root tab with Magisk download/flash and root check
- add device polling to disable buttons when no phone is connected
- document rooting steps for Samsung J3
- link new rooting guide from the docs

## Testing
- `python -m py_compile flash.py`


------
https://chatgpt.com/codex/tasks/task_e_6879db101cc083228ef8f5548dc05f94