### PR TITLE
Add root info docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This project provides a Python-based application to flash a Samsung Galaxy J3 (S
 - Optionally installs Magisk for root and a custom APK
 - Logs actions to `flasher.log`
 
+### Root access?
+
+See the [root info](docs/root.html) page for details on when root is useful and why it is optional for Travelbot.
+
 ## Directory Structure
 - `scripts/` – optional helper scripts or recovery tools
 - `images/` – logo or branding assets

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ These HTML pages can be viewed locally or published with GitHub Pages. Enable Pa
 
 - `index.html` – short introduction and navigation
 - `frequent-issues.html` – instructions for solving Factory Reset Protection (FRP) lock and other common problems
+- `root.html` – explains why Travelbot works without root and when you might need it
 
 The styling and behaviour are implemented in `style.css` and `script.js`.

--- a/docs/frequent-issues.html
+++ b/docs/frequent-issues.html
@@ -9,6 +9,7 @@
   <nav>
     <a href="index.html">Home</a>
     <a href="frequent-issues.html" class="active">Frequent issues</a>
+    <a href="root.html">Root info</a>
   </nav>
   <div class="container">
     <h1>🔓 FRP Lock oplossen (Samsung Galaxy J3 - SM-J320FN)</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,12 +9,14 @@
   <nav>
     <a href="index.html" class="active">Home</a>
     <a href="frequent-issues.html">Frequent issues</a>
+    <a href="root.html">Root info</a>
   </nav>
   <div class="container">
     <h1>Travelbot Flasher</h1>
     <p>This site hosts documentation for the Travelbot flasher tool.</p>
     <p>The application flashes a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM and provides a GUI built with PyQt6.</p>
     <p>Browse the <strong>Frequent issues</strong> tab for help with common problems such as FRP lock.</p>
+    <p>See <a href="root.html">Root info</a> to learn when root access might be useful.</p>
   </div>
   <script src="script.js"></script>
 </body>

--- a/docs/root.html
+++ b/docs/root.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Is root nodig voor Travelbot?">
+  <title>Heb ik root nodig voor Travelbot?</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="frequent-issues.html">Frequent issues</a>
+    <a href="root.html" class="active">Root info</a>
+  </nav>
+  <div class="container">
+    <h1>Heb ik root nodig voor Travelbot?</h1>
+    <p>Nee – <strong>voor Travelbot is rooten niet noodzakelijk</strong>. Je kunt vrijwel alle functies gebruiken zonder roottoegang.</p>
+    <h2>✅ Wat werkt zonder root?</h2>
+    <table>
+      <tr><th>Functie</th><th>Vereist root?</th></tr>
+      <tr><td>📍 Locatie uitlezen via GPS</td><td>❌ Nee</td></tr>
+      <tr><td>🔊 Tekst-naar-spraak uitvoeren</td><td>❌ Nee</td></tr>
+      <tr><td>🌐 Reacties ophalen via backend (AI)</td><td>❌ Nee</td></tr>
+      <tr><td>🎵 Reacties afspelen via TTS of MP3</td><td>❌ Nee</td></tr>
+      <tr><td>🧭 In foreground-service draaien</td><td>❌ Nee</td></tr>
+      <tr><td>🧑‍💻 Gebruikersinterface en knoppen</td><td>❌ Nee</td></tr>
+      <tr><td>🚗 Automatisch opstarten bij boot</td><td>❌ Nee <em>(mogelijk via manifest)</em></td></tr>
+    </table>
+    <p>Travelbot is ontworpen om te draaien op oude Android-telefoons zonder root.</p>
+    <h2>🔐 Wanneer is root wél nuttig?</h2>
+    <p>Alleen als je geavanceerde systeemacties wilt zoals:</p>
+    <ul>
+      <li>Vliegtuigmodus aan/uit zetten</li>
+      <li>Andere apps afsluiten of starten</li>
+      <li>Meldingen van andere apps blokkeren</li>
+      <li>Travelbot als <strong>systeemapp</strong> installeren</li>
+      <li>TTS-engine vervangen of manipuleren op systeemniveau</li>
+    </ul>
+    <p>Voor de meeste gebruikers is dit <strong>niet nodig</strong>.</p>
+    <h2>🧠 Waarom TWRP dan wél?</h2>
+    <p>TWRP (TeamWin Recovery Project) gebruik je alleen om:</p>
+    <ul>
+      <li>LineageOS of een lichte custom ROM te installeren</li>
+      <li>Travelbot eenvoudig te installeren</li>
+      <li>FRP/OEM locks te omzeilen</li>
+      <li>Apparaten te "recyclen" voor hergebruik</li>
+    </ul>
+    <p>TWRP ≠ root, maar maakt rooten mogelijk voor wie dat wíl.</p>
+    <h2>📌 Advies</h2>
+    <blockquote>Gebruik root alleen als je <strong>weet wat je doet</strong>, of specifieke systeemtoegang nodig hebt.<br>Travelbot werkt standaard <strong>zonder root</strong>. De root-tab in de GUI is optioneel.</blockquote>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/flash.py
+++ b/flash.py
@@ -46,7 +46,8 @@ INSTRUCTION_TEXT = (
 "4. Gebruik 'Install Tools' om ADB en Heimdall te installeren indien nodig.\n"
 "5. Kies 'Auto Flash TWRP' voor automatische flashing van de recovery.\n"
 "6. Handmatig flashen kan via 'Flash TWRP' of 'Flash LineageOS'.\n"
-"7. Alle voortgang verschijnt hieronder en in flasher.log.\n"
+    "7. Alle voortgang verschijnt hieronder en in flasher.log.\n"
+    "8. Lees docs/root.html voor uitleg over root-toegang.\n"
 )
 
 IS_WINDOWS = platform.system().lower() == 'windows'


### PR DESCRIPTION
## Summary
- add root info page detailing when rooting is optional
- link to new page from site navigation, index, README and GUI help text
- mention new page in docs README

## Testing
- `python -m py_compile flash.py`


------
https://chatgpt.com/codex/tasks/task_e_6879e99c5a988322b12d366cc660491e