### PR TITLE
Voeg extra functies en documentatieknop toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project provides a Python-based application to flash a Samsung Galaxy J3 (S
 - Button to install ADB and check for Heimdall
 - Extra buttons for rebooting, viewing logs, and clearing the log
 - Built-in help window with step-by-step instructions
-- Uses a simple ttk theme for a cleaner interface
+- Quick links to the bundled HTML documentation
 - Optionally installs Magisk for root and a custom APK
 - Logs actions to `flasher.log`
 

--- a/flash.py
+++ b/flash.py
@@ -21,6 +21,7 @@ from PyQt6.QtWidgets import (
     QTabWidget,
     QHBoxLayout,
 )
+import webbrowser
 from PyQt6.QtCore import Qt, QTimer
 
 import sys
@@ -383,6 +384,12 @@ def clear_log(text_widget):
     log('Log cleared.', text_widget)
 
 
+def open_docs():
+    """Open the local HTML documentation in the default browser."""
+    doc = Path('docs/index.html').resolve()
+    webbrowser.open(f'file://{doc}')
+
+
 def show_help():
     show_info('Help', INSTRUCTION_TEXT)
 
@@ -599,6 +606,20 @@ class MainWindow(QWidget):
         self.progress.setVisible(False)
         layout.addWidget(self.progress)
 
+        button_row = QHBoxLayout()
+
+        self.btn_check_device = QPushButton('Detecteer toestel')
+        self.btn_check_device.clicked.connect(lambda: check_device(self.log_box))
+        button_row.addWidget(self.btn_check_device)
+
+        self.btn_install_tools = QPushButton('Install Tools')
+        self.btn_install_tools.clicked.connect(
+            lambda: start_install_tools(self.log_box, self.progress)
+        )
+        button_row.addWidget(self.btn_install_tools)
+
+        layout.addLayout(button_row)
+
         self.btn_flash_twrp = QPushButton('Flash TWRP')
         self.btn_flash_twrp.clicked.connect(
             lambda: start_flash_recovery(self.log_box, self.progress)
@@ -616,6 +637,26 @@ class MainWindow(QWidget):
             lambda: install_travelbot_apk(self.log_box)
         )
         layout.addWidget(self.btn_install_apk)
+
+        other_row = QHBoxLayout()
+
+        self.btn_view_log = QPushButton('Bekijk log')
+        self.btn_view_log.clicked.connect(open_log_file)
+        other_row.addWidget(self.btn_view_log)
+
+        self.btn_clear_log = QPushButton('Leeg log')
+        self.btn_clear_log.clicked.connect(lambda: clear_log(self.log_box))
+        other_row.addWidget(self.btn_clear_log)
+
+        self.btn_help = QPushButton('Help')
+        self.btn_help.clicked.connect(show_help)
+        other_row.addWidget(self.btn_help)
+
+        self.btn_docs = QPushButton('Open Handleiding')
+        self.btn_docs.clicked.connect(open_docs)
+        other_row.addWidget(self.btn_docs)
+
+        layout.addLayout(other_row)
 
         self.tabs.addTab(tab, '📲 Flasher')
 
@@ -651,9 +692,13 @@ class MainWindow(QWidget):
             self.btn_flash_twrp,
             self.btn_flash_rom,
             self.btn_install_apk,
+            self.btn_check_device,
+            self.btn_install_tools,
             self.btn_dl_magisk,
             self.btn_flash_magisk,
             self.btn_check_root,
+            self.btn_view_log,
+            self.btn_clear_log,
         ]:
             btn.setEnabled(connected)
 


### PR DESCRIPTION
## Samenvatting
- voeg knoppen toe om apparaat te detecteren, tools te installeren, log te bekijken/legen
- voeg Help en handleiding-knoppen toe
- implementatie `open_docs` functie
- update README met nieuwe features

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile flash.py`
- `python flash.py` *(faalt: xcb plugin ontbreekt)*

------
https://chatgpt.com/codex/tasks/task_e_6879e9f6f3fc83228292f495df375edf