### PR TITLE
Add GUI root install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project provides a Python-based application to flash a Samsung Galaxy J3 (S
 ### Root access?
 
 See the [root info](docs/root.html) page for details on when root is useful and why it is optional for Travelbot.
+For step-by-step instructions on enabling root, check the [root installation guide](docs/root-install.html).
 
 ## Directory Structure
 - `scripts/` – optional helper scripts or recovery tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,6 @@ These HTML pages can be viewed locally or published with GitHub Pages. Enable Pa
 - `index.html` – short introduction and navigation
 - `frequent-issues.html` – instructions for solving Factory Reset Protection (FRP) lock and other common problems
 - `root.html` – explains why Travelbot works without root and when you might need it
+- `root-install.html` – step-by-step guide for installing root via the GUI
 
 The styling and behaviour are implemented in `style.css` and `script.js`.

--- a/docs/frequent-issues.html
+++ b/docs/frequent-issues.html
@@ -10,6 +10,7 @@
     <a href="index.html">Home</a>
     <a href="frequent-issues.html" class="active">Frequent issues</a>
     <a href="root.html">Root info</a>
+    <a href="root-install.html">Root installatie</a>
   </nav>
   <div class="container">
     <h1>🔓 FRP Lock oplossen (Samsung Galaxy J3 - SM-J320FN)</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
     <a href="index.html" class="active">Home</a>
     <a href="frequent-issues.html">Frequent issues</a>
     <a href="root.html">Root info</a>
+    <a href="root-install.html">Root install</a>
   </nav>
   <div class="container">
     <h1>Travelbot Flasher</h1>
@@ -17,6 +18,7 @@
     <p>The application flashes a Samsung Galaxy J3 (SM-J320FN) with a minimal LineageOS ROM and provides a GUI built with PyQt6.</p>
     <p>Browse the <strong>Frequent issues</strong> tab for help with common problems such as FRP lock.</p>
     <p>See <a href="root.html">Root info</a> to learn when root access might be useful.</p>
+    <p>Follow the <a href="root-install.html">Root install guide</a> for detailed steps.</p>
   </div>
   <script src="script.js"></script>
 </body>

--- a/docs/root-install.html
+++ b/docs/root-install.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Root installeren via de Travelbot GUI">
+  <title>Travelbot Root Installatiegids</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="frequent-issues.html">Frequent issues</a>
+    <a href="root.html">Root info</a>
+    <a href="root-install.html" class="active">Root installatie</a>
+  </nav>
+  <div class="container">
+    <h1>🔓 Travelbot Root Installatiegids (GUI-versie)</h1>
+    <p>Deze gids laat je stap voor stap zien hoe je roottoegang installeert op je Samsung Galaxy J3 (SM-J320FN) via de Travelbot Flash Tool met grafische interface.</p>
+
+    <div class="step">
+      <h3 class="toggle">1. Open de Travelbot Flash Tool</h3>
+      <ul>
+        <li>Start het programma <code>flash_gui_tabs.py</code></li>
+        <li>Ga naar het tabblad <strong>🔓 Root</strong></li>
+      </ul>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">2. Download Magisk v23.0</h3>
+      <p>Klik op:</p>
+      <pre><code>[ Download Magisk v23.0 ]</code></pre>
+      <p>✔️ De tool downloadt automatisch het ZIP-bestand en slaat het op in <code>downloads/</code>.</p>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">3. Push Magisk naar je toestel</h3>
+      <p>Klik op:</p>
+      <pre><code>[ Flash Magisk via TWRP ]</code></pre>
+      <p>✔️ De tool stuurt het ZIP-bestand via ADB naar <code>/sdcard/Magisk-v23.0.zip</code>.</p>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">4. Herstart naar TWRP Recovery</h3>
+      <p>Klik op:</p>
+      <pre><code>[ Reboot naar TWRP ]</code></pre>
+      <p>📱 Je toestel zal opnieuw opstarten in TWRP-recovery (houd Volume Up + Home + Power ingedrukt als nodig).</p>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">5. Flash Magisk in TWRP</h3>
+      <p>Handmatig op je toestel in TWRP:</p>
+      <ol>
+        <li>Tik op <code>Install</code></li>
+        <li>Navigeer naar <code>/sdcard/</code></li>
+        <li>Selecteer <code>Magisk-v23.0.zip</code></li>
+        <li>Swipe om te flashen</li>
+        <li>Reboot naar Android</li>
+      </ol>
+    </div>
+
+    <div class="step">
+      <h3 class="toggle">6. Controleer rootstatus</h3>
+      <p>Na herstart, terug in de Travelbot GUI:</p>
+      <p>Klik op:</p>
+      <pre><code>[ Controleer rootstatus ]</code></pre>
+      <p>✔️ De tool checkt via ADB of het <code>su</code>-commando beschikbaar is.</p>
+      <ul>
+        <li>✅ Root actief: "Root is correct geïnstalleerd"</li>
+        <li>❌ Geen root: "Magisk niet gedetecteerd"</li>
+      </ul>
+    </div>
+
+    <h2>ℹ️ Root is optioneel</h2>
+    <p>Travelbot werkt <strong>volledig zonder root</strong>. Root is alleen nodig als je extra systeemcontrole of diepte-integratie wilt.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/root.html
+++ b/docs/root.html
@@ -11,6 +11,7 @@
     <a href="index.html">Home</a>
     <a href="frequent-issues.html">Frequent issues</a>
     <a href="root.html" class="active">Root info</a>
+    <a href="root-install.html">Root installatie</a>
   </nav>
   <div class="container">
     <h1>Heb ik root nodig voor Travelbot?</h1>
@@ -48,6 +49,7 @@
     <p>TWRP ≠ root, maar maakt rooten mogelijk voor wie dat wíl.</p>
     <h2>📌 Advies</h2>
     <blockquote>Gebruik root alleen als je <strong>weet wat je doet</strong>, of specifieke systeemtoegang nodig hebt.<br>Travelbot werkt standaard <strong>zonder root</strong>. De root-tab in de GUI is optioneel.</blockquote>
+    <p>Wil je toch rooten? Volg dan de <a href="root-install.html">root installatiegids</a> voor de stappen in de Travelbot GUI.</p>
   </div>
   <script src="script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add root install guide to docs site
- link to the new guide from existing pages
- mention root install in README files

## Testing
- `python -m py_compile flash.py`


------
https://chatgpt.com/codex/tasks/task_e_6879ed27dbf8832284e6bb83c45a30fa